### PR TITLE
[WIP] Implement "max_matches" param to fail on duplicated results

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,15 @@ of the form `lat,lon,tolerated deviation in meters`, e.g. `51.0,10.3,700`.
 
 Optional columns:
 * `limit`: decide how many results you want to look at for finding your result
-(defaul: 1)
+(default: 1)
 * `lat`, `lon`: if you want to add a center for the search
 * `comment`: if you want to take control of the ouput of the test in the
 command line
 * `lang`: language
 * `skip`: add a `skip` message if you want a test to be always skipped (feature
 not supported yet for example)
+* `max_matches`: maximum number of results that should match expected value.
+Should be used such as `limit` > `max_matches`. (default: no limit)
 
 ### YAML
 

--- a/conftest.py
+++ b/conftest.py
@@ -133,6 +133,13 @@ class BaseFlatItem(pytest.Item):
         self.comment = kwargs.get('comment')
         self.skip = kwargs.get('skip')
         self.mark = kwargs.get('mark', [])
+
+        self.max_matches = kwargs.get('max_matches')
+        if self.max_matches:
+            self.max_matches = int(self.max_matches)
+        else:
+            self.max_matches = None
+
         for mark in self.mark:
             self.add_marker(mark)
 
@@ -143,7 +150,8 @@ class BaseFlatItem(pytest.Item):
             'query': self.query,
             'expected': self.expected,
             'lang': self.lang,
-            'comment': self.comment
+            'comment': self.comment,
+            'max_matches': self.max_matches
         }
         if self.lat and self.lon:
             kwargs['center'] = [self.lat, self.lon]


### PR DESCRIPTION
At this stage, this PR implements a new optional column `max_matches` in csv test files.
Such tests will fail if more than `max_matches` results match the expected values.

NB: this requires `limit` > `max_matches`.
Currently default `limit` is 1, so both params should be set in test items to use the new feature.

Should we provide an option to check for duplicates on existing tests ?
And should such an option override the default `limit` value as well ?
