### PR TITLE
Implement option to disable https certificate verification

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,12 @@ def pytest_addoption(parser):
         help="The URL to use for running tests against."
     )
     parser.addoption(
+        '--https-no-verify',
+        dest="https_no_verify",
+        action="store_true",
+        help="Disable https certificate verification"
+    )
+    parser.addoption(
         '--max-run',
         dest="max_run",
         type=int,
@@ -78,6 +84,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     CONFIG['API_URL'] = config.getoption('--api-url')
+    CONFIG['HTTPS_NO_VERIFY'] = config.getoption('--https-no-verify')
     CONFIG['MAX_RUN'] = config.getoption('--max-run')
     CONFIG['LOOSE_COMPARE'] = config.getoption('--loose-compare')
     CONFIG['GEOJSON'] = config.getoption('--geojson')

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -14,6 +14,7 @@ MUNICH = [43.731245, 7.419744]
 AUCKLAND = [-36.853467, 174.765551]
 CONFIG = {
     'API_URL': "http://localhost:5001/api/",
+    'HTTPS_NO_VERIFY': False,
     'LOOSE_COMPARE': False,
     'MAX_RUN': 0,  # means no limit
     'GEOJSON': False,
@@ -174,7 +175,12 @@ class SearchException(Exception):
 
 
 def search(**params):
-    r = http.get(CONFIG['API_URL'], params=params)
+    kwargs = {
+        "params": params
+    }
+    if CONFIG['HTTPS_NO_VERIFY']:
+        kwargs['verify'] = False
+    r = http.get(CONFIG['API_URL'], **kwargs)
     if not r.status_code == 200:
         raise HttpSearchException(error="Non 200 response")
     return r.json()


### PR DESCRIPTION
In order to run geocoder-tester on an internal https endpoint.