### PR TITLE
Focus with new 'zoom' param

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Optional columns:
 * `limit`: decide how many results you want to look at for finding your result
 (default: 1)
 * `lat`, `lon`: if you want to add a center for the search
+* `radius`: configure the approximate radius for the search, in kilometers (default: TODO)
 * `comment`: if you want to take control of the ouput of the test in the
 command line
 * `lang`: language

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Optional columns:
 * `limit`: decide how many results you want to look at for finding your result
 (default: 1)
 * `lat`, `lon`: if you want to add a center for the search
-* `radius`: configure the approximate radius for the search, in kilometers (default: TODO)
+* `zoom`: the zoom level of the map where the query originates. This will impact the radius scale of the focused search (optional)
 * `comment`: if you want to take control of the ouput of the test in the
 command line
 * `lang`: language

--- a/conftest.py
+++ b/conftest.py
@@ -160,6 +160,7 @@ class BaseFlatItem(pytest.Item):
         super().__init__(name, parent)
         self.lat = kwargs.get('lat')
         self.lon = kwargs.get('lon')
+        self.radius = kwargs.get('radius')
         self.lang = kwargs.get('lang')
         self.limit = kwargs.get('limit')
         self.comment = kwargs.get('comment')
@@ -183,7 +184,8 @@ class BaseFlatItem(pytest.Item):
             'expected': self.expected,
             'lang': self.lang,
             'comment': self.comment,
-            'max_matches': self.max_matches
+            'max_matches': self.max_matches,
+            'radius': self.radius,
         }
         if self.lat and self.lon:
             kwargs['center'] = [self.lat, self.lon]

--- a/conftest.py
+++ b/conftest.py
@@ -160,7 +160,7 @@ class BaseFlatItem(pytest.Item):
         super().__init__(name, parent)
         self.lat = kwargs.get('lat')
         self.lon = kwargs.get('lon')
-        self.radius = kwargs.get('radius')
+        self.zoom = kwargs.get('zoom')
         self.lang = kwargs.get('lang')
         self.limit = kwargs.get('limit')
         self.comment = kwargs.get('comment')
@@ -185,7 +185,7 @@ class BaseFlatItem(pytest.Item):
             'lang': self.lang,
             'comment': self.comment,
             'max_matches': self.max_matches,
-            'radius': self.radius,
+            'zoom': self.zoom,
         }
         if self.lat and self.lon:
             kwargs['center'] = [self.lat, self.lon]

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -199,16 +199,19 @@ def compare_values(get, expected):
 
 def assert_search(query, expected, limit=1,
                   comment=None, lang=None, center=None,
-                  max_matches=None, radius=None):
+                  max_matches=None, zoom=None):
     query_limit = max(CONFIG['CHECK_DUPLICATES'] or 0, int(limit))
     params = {"q": query, "limit": query_limit}
+
     if lang:
         params['lang'] = lang
+
     if center:
         params['lat'] = center[0]
         params['lon'] = center[1]
-    if radius:
-        params['radius'] = radius
+    if zoom:
+        params['zoom'] = zoom
+
     raw_results = search(**params)
     results = raw_results['features'][:int(limit)]
 

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -199,7 +199,7 @@ def compare_values(get, expected):
 
 def assert_search(query, expected, limit=1,
                   comment=None, lang=None, center=None,
-                  max_matches=None):
+                  max_matches=None, radius=None):
     query_limit = max(CONFIG['CHECK_DUPLICATES'] or 0, int(limit))
     params = {"q": query, "limit": query_limit}
     if lang:
@@ -207,6 +207,8 @@ def assert_search(query, expected, limit=1,
     if center:
         params['lat'] = center[0]
         params['lon'] = center[1]
+    if radius:
+        params['radius'] = radius
     raw_results = search(**params)
     results = raw_results['features'][:int(limit)]
 

--- a/geocoder_tester/world/test_focus.csv
+++ b/geocoder_tester/world/test_focus.csv
@@ -1,7 +1,7 @@
-query;lat;lon;radius;limit;lang;expected_name;expected_housenumber;expected_street;expected_city;expected_postcode;expected_country
+query;lat;lon;radius;limit;lang;expected_name;expected_housenumber;expected_street;expected_city;expected_postcode;expected_coordinate
 cathédrale notre dame;47.0778819;3.2747108;500;1;fr;Cathédrale Notre-Dame;;;Paris;75004;
 cathédrale notre dame;45.7937570;-73.6104255;500;1;fr;Basilique cathédrale Notre-Dame-de-Québec;;;Québec;;
-normale sup;47.0778819;3.2747108;500;1;fr;École normale supérieure - Université PSL;;;Paris;75009;
+normale sup;47.0778819;3.2747108;500;1;fr;École normale supérieure - Université PSL;;;Paris;;
 normale sup;42.6156839;12.3164424;500;1;fr;Scuola Normale Superiore;;;Pisa;56126;
 louvre;48.8549087;2.3428067;30;1;fr;Musée du Louvre;;;Paris;75001;
 louvre;50.4426796;2.8228790;30;1;fr;Louvre Lens;;;Lens;62300;
@@ -11,9 +11,9 @@ rue des tennis;48.8536903;2.3358433;30;1;fr;Rue des Tennis;;;Paris;75018;
 rue des tennis;47.9822568;0.1603311;30;1;fr;Rue des Tennis;;;Le Mans;;
 rue saint émilion;44.8362641;-0.5839494;30;1;fr;Rue de Saint-Émilion;;;Bordeaux;;
 rue saint émilion;45.7145486;-0.5631468;30;1;fr;Rue du Saint-Emilion;;;Chaniers;17610;
-milan;39.0566031;-99.7834429;1000;1;fr;Milan;;;;;United States
-milan;43.0195313;12.3970667;1000;1;fr;Milan;;;;;Italia
-villeneuve;47.0778819;3.2747108;500;Villeneuve;;;;;France
-villeneuve;-26.8442970;131.0716250;500;Villeneuve;;;;;Australia
-richebourg;48.8590244;2.3385286;50;Richebourg;;;;78550;
-richebourg;50.6302844;3.0605593;50;Richebourg;;;;62136;
+milan;43.0195313;12.3970667;1000;1;fr;Milan;;;;;45.4043815,8.978141,50000
+milan;-99.7834429;40;1000;1;fr;Milan;;;;;37.2597959,-97.6732042,50000
+villeneuve;47.0778819;3.2747108;500;1;fr;Villeneuve;;;;;
+villeneuve;-26.8442970;131.0716250;500;1;fr;Villeneuve;;;;;
+richebourg;48.8590244;2.3385286;50;1;fr;Richebourg;;;;;48.8265237,1.6359872,10000
+richebourg;52.6302844;3.0605593;50;1;fr;Richebourg;;;;;50.5824045,2.7284325,10000

--- a/geocoder_tester/world/test_focus.csv
+++ b/geocoder_tester/world/test_focus.csv
@@ -1,0 +1,19 @@
+query;lat;lon;radius;limit;lang;expected_name;expected_housenumber;expected_street;expected_city;expected_postcode;expected_country
+cathédrale notre dame;47.0778819;3.2747108;500;1;fr;Cathédrale Notre-Dame;;;Paris;75004;
+cathédrale notre dame;45.7937570;-73.6104255;500;1;fr;Basilique cathédrale Notre-Dame-de-Québec;;;Québec;;
+normale sup;47.0778819;3.2747108;500;1;fr;École normale supérieure - Université PSL;;;Paris;75009;
+normale sup;42.6156839;12.3164424;500;1;fr;Scuola Normale Superiore;;;Pisa;56126;
+louvre;48.8549087;2.3428067;30;1;fr;Musée du Louvre;;;Paris;75001;
+louvre;50.4426796;2.8228790;30;1;fr;Louvre Lens;;;Lens;62300;
+musée d'histoire naturelle;51.5071670;-0.1276573;30;1;fr;Musée d'histoire naturelle;;;London;;
+musée d'histoire naturelle;50.6259632;3.1093266;30;1;fr;Musée d'Histoire Naturelle et de Géologie;;;Lille;59000;
+rue des tennis;48.8536903;2.3358433;30;1;fr;Rue des Tennis;;;Paris;75018;
+rue des tennis;47.9822568;0.1603311;30;1;fr;Rue des Tennis;;;Le Mans;;
+rue saint émilion;44.8362641;-0.5839494;30;1;fr;Rue de Saint-Émilion;;;Bordeaux;;
+rue saint émilion;45.7145486;-0.5631468;30;1;fr;Rue du Saint-Emilion;;;Chaniers;17610;
+milan;39.0566031;-99.7834429;1000;1;fr;Milan;;;;;United States
+milan;43.0195313;12.3970667;1000;1;fr;Milan;;;;;Italia
+villeneuve;47.0778819;3.2747108;500;Villeneuve;;;;;France
+villeneuve;-26.8442970;131.0716250;500;Villeneuve;;;;;Australia
+richebourg;48.8590244;2.3385286;50;Richebourg;;;;78550;
+richebourg;50.6302844;3.0605593;50;Richebourg;;;;62136;

--- a/geocoder_tester/world/test_focus.csv
+++ b/geocoder_tester/world/test_focus.csv
@@ -1,19 +1,40 @@
-query;lat;lon;radius;limit;lang;expected_name;expected_housenumber;expected_street;expected_city;expected_postcode;expected_coordinate
-cathédrale notre dame;47.0778819;3.2747108;500;1;fr;Cathédrale Notre-Dame;;;Paris;75004;
-cathédrale notre dame;45.7937570;-73.6104255;500;1;fr;Basilique cathédrale Notre-Dame-de-Québec;;;Québec;;
-normale sup;47.0778819;3.2747108;500;1;fr;École normale supérieure - Université PSL;;;Paris;;
-normale sup;42.6156839;12.3164424;500;1;fr;Scuola Normale Superiore;;;Pisa;56126;
-louvre;48.8549087;2.3428067;30;1;fr;Musée du Louvre;;;Paris;75001;
-louvre;50.4426796;2.8228790;30;1;fr;Louvre Lens;;;Lens;62300;
-musée d'histoire naturelle;51.5071670;-0.1276573;30;1;fr;Musée d'histoire naturelle;;;London;;
-musée d'histoire naturelle;50.6259632;3.1093266;30;1;fr;Musée d'Histoire Naturelle et de Géologie;;;Lille;59000;
-rue des tennis;48.8536903;2.3358433;30;1;fr;Rue des Tennis;;;Paris;75018;
-rue des tennis;47.9822568;0.1603311;30;1;fr;Rue des Tennis;;;Le Mans;;
-rue saint émilion;44.8362641;-0.5839494;30;1;fr;Rue de Saint-Émilion;;;Bordeaux;;
-rue saint émilion;45.7145486;-0.5631468;30;1;fr;Rue du Saint-Emilion;;;Chaniers;17610;
-milan;43.0195313;12.3970667;1000;1;fr;Milan;;;;;45.4043815,8.978141,50000
-milan;-99.7834429;40;1000;1;fr;Milan;;;;;37.2597959,-97.6732042,50000
-villeneuve;47.0778819;3.2747108;500;1;fr;Villeneuve;;;;;
-villeneuve;-26.8442970;131.0716250;500;1;fr;Villeneuve;;;;;
-richebourg;48.8590244;2.3385286;50;1;fr;Richebourg;;;;;48.8265237,1.6359872,10000
-richebourg;52.6302844;3.0605593;50;1;fr;Richebourg;;;;;50.5824045,2.7284325,10000
+query;lat;lon;zoom;limit;lang;expected_name;expected_housenumber;expected_street;expected_city;expected_postcode;expected_coordinate
+cathédrale notre dame;47.0778819;3.2747108;3;1;fr;Cathédrale Notre-Dame;;;Paris;75004;
+cathédrale notre dame;45.7937570;-73.6104255;8;1;fr;Basilique cathédrale Notre-Dame-de-Québec;;;Québec;;
+normale sup;47.0778819;3.2747108;8;1;fr;École normale supérieure;;;Paris;;
+normale sup;42.6156839;12.3164424;8;1;fr;Scuola Normale Superiore;;;Pisa;56126;
+louvre;48.8549087;2.3428067;12;1;fr;Musée du Louvre;;;Paris;75001;
+louvre;50.4426796;2.8228790;12;1;fr;Louvre Lens;;;Lens;62300;
+musée d'histoire naturelle;51.5071670;-0.1276573;12;1;fr;Musée d'histoire naturelle;;;London;;
+musée d'histoire naturelle;50.6259632;3.1093266;12;1;fr;Musée d'Histoire Naturelle et de Géologie;;;Lille;59000;
+rue des tennis;48.8536903;2.3358433;12;1;fr;Rue des Tennis;;;Paris;75018;
+rue des tennis;47.9822568;0.1603311;12;1;fr;Rue des Tennis;;;Le Mans;;
+rue saint émilion;44.8362641;-0.5839494;12;1;fr;Rue de Saint-Émilion;;;Bordeaux;;
+rue saint émilion;45.7145486;-0.5631468;12;1;fr;Rue du Saint-Emilion;;;Chaniers;17610;
+milan;43.0195313;12.3970667;8;1;fr;Milan;;;;;45.4043815,8.978141,50000
+milan;40;-99.7834429;8;1;fr;Milan;;;;;37.2597959,-97.6732042,50000
+villeneuve;47.0778819;3.2747108;8;1;fr;Villeneuve;;;;;
+villeneuve;-26.8442970;131.0716250;8;1;fr;Villeneuve;;;;;
+richebourg;48.8590244;2.3385286;10;1;fr;Richebourg;;;;;48.8265237,1.6359872,10000
+richebourg;52.6302844;3.0605593;10;1;fr;Richebourg;;;;;50.5824045,2.7284325,10000
+Gard;63.95995;24.29763700237717;4;1;fr;Gard;;;;;43.95995,4.297637002377168,15000
+Gard;44.95995;5.297637002377168;12;1;fr;Gard;;;;;43.95995,4.297637002377168,15000
+indre;66.81210565;21.538205155705626;4;1;fr;Indre;;;;;46.81210565,1.5382051557056249,15000
+indre;47.81210565;2.538205155705625;12;1;fr;Indre;;;;;46.81210565,1.5382051557056249,15000
+Doha;45.283333330000005;71.533333;4;1;en;Doha;;;;;"25.28333333,51.533333,5000"
+"Doha, Qatar";45.283333330000005;71.533333;4;1;en;Doha;;;;;"25.28333333,51.533333,5000"
+"Kingston, Jamaica";38.0;-56.8;4;1;en;Kingston;;;;;"18,-76.8,5000"
+"Huambo";10.5;14.4;4;1;"fr";"Huambo";;;;;"-12.766667,15.733333,5000"
+"Aglantsiá";46.8;4.3;5;1;"fr";"Aglantsiá";;;;;"35.139489,33.404711,5000"
+"Memphis (Tennessee)";48.8;2.4;8;1;"fr";"Memphis";;;;;"35.10450226109507,-89.97936576058625,5000"
+"Memphis (Tennessee)";55.11;-69.98;4';1;"fr";"Memphis";;;;;"35.10450226109507,-89.97936576058625,5000"
+"Las Vegas (Nevada)";48.8;2.4;8;1;"fr";"Las Vegas";;;;;"36.169941,-115.13983,5000"
+"Las Vegas (Nevada)";48.8;2.4;4;1;"fr";"Las Vegas";;;;;"36.169941,-115.13983,5000"
+"Trenton (New Jersey)";60.220582;-54.759716999999995;4;1;"fr";"Trenton";;;;;"40.220582,-74.759717,5000"
+"Trenton (New Jersey)";49.9;3.1;7;1;"fr";"Trenton";;;;;"40.220582,-74.759717,5000"
+"Londonderry";45.8;3.2;6;1;"fr";"Londonderry";;;;;"54.996612,-7.308575,5000"
+"Bréda";45.9;4.2;6;1;"fr";"Bréda";;;;;"51.571915,4.768323,5000"
+"Bâle";55.6;11.9;4;1;"fr";"Bâle";;;;;"47.559599,7.588576,5000"
+Le Pal;51.5;7.1;4;1;"fr";Le Pal;;;;03290;"46.50798,3.63015,500"
+Château de Chenonceau;48.8;1.2;8;1;"fr";Château de Chenonceau;;;;37150;"47.324870,1.070301,100"
+Pointe du Hoc;49.68;-0.23;7;1;"fr";La Pointe du Hoc;;;;;"49.397189,-0.98927,500"


### PR DESCRIPTION
This PR extends and replaces #40, now that the `zoom` param has been implemented in https://github.com/QwantResearch/idunn/pull/162

Compared to #40, additional tests are present in "test_focus.csv". They have been built mostly manually, after inspecting results variation on existing tests that include "expected_coordinate", with different focus/zoom values in the query .